### PR TITLE
fixed ValueError with certain image resolutions

### DIFF
--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -1,0 +1,39 @@
+import logging
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from tf_bodypix.model import BodyPixModelWrapper
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+ANY_INT_FACTOR_1 = 5
+
+
+class TestBodyPixModelWrapper:
+    def test_should_be_able_to_padded_and_resized_image_matching_output_stride_plus_one(self):
+        predict_fn = MagicMock(name='predict_fn')
+        output_stride = 16
+        internal_resolution = 0.5
+        model = BodyPixModelWrapper(
+            predict_fn=predict_fn,
+            output_stride=output_stride,
+            internal_resolution=internal_resolution
+        )
+        resolution_matching_output_stride_plus_1 = int(
+            (output_stride * ANY_INT_FACTOR_1 + 1) / internal_resolution
+        )
+        LOGGER.debug(
+            'resolution_matching_output_stride_plus_1: %s',
+            resolution_matching_output_stride_plus_1
+        )
+        image = np.ones(
+            shape=(
+                resolution_matching_output_stride_plus_1,
+                resolution_matching_output_stride_plus_1,
+                3
+            )
+        )
+        model.predict_single(image)

--- a/tf_bodypix/bodypix_js_utils/util.py
+++ b/tf_bodypix/bodypix_js_utils/util.py
@@ -24,9 +24,9 @@ def to_valid_input_resolution(
     input_resolution: int, output_stride: int
 ) -> int:
     if is_valid_input_resolution(input_resolution, output_stride):
-        return input_resolution
+        return int(input_resolution)
 
-    return math.floor(input_resolution / output_stride) * output_stride + 1
+    return int(math.floor(input_resolution / output_stride) * output_stride + 1)
 
 
 # see toInputResolutionHeightAndWidth

--- a/tf_bodypix/model.py
+++ b/tf_bodypix/model.py
@@ -301,6 +301,10 @@ class BodyPixModelWrapper:
     def get_padded_and_resized(
         self, image: np.ndarray, model_input_size: ImageSize
     ) -> Tuple[np.ndarray, Padding]:
+        LOGGER.debug(
+            'pad_and_resize_to: image.shape=%s, model_input_size=%s',
+            image.shape, model_input_size
+        )
         return pad_and_resize_to(
             image,
             model_input_size.height,


### PR DESCRIPTION
fixes #44

fixed predict with internal image resolution matching output stride plus one.
when that happens then a different code path is keeping the width or height as a float, which tf doesn't want to convert to int.