### PR TITLE
darken background when adding overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python -m tf_bodypix \
     "https://www.dropbox.com/s/s7jga3f0dreavlb/video-of-a-man-laughing-and-happy-1608393-360p.mp4?dl=1" \
     --show-output \
     --threshold=0.75 \
-    --add-overlay-alpha=0.5 \
+    --mask-alpha=0.5 \
     --colored
 ```
 
@@ -148,7 +148,7 @@ python -m tf_bodypix \
     --source webcam:0 \
     --show-output \
     --threshold=0.75 \
-    --add-overlay-alpha=0.5 \
+    --mask-alpha=0.5 \
     --colored
 ```
 
@@ -162,7 +162,7 @@ python -m tf_bodypix \
     --source webcam:0 \
     --output /dev/videoN \
     --threshold=0.75 \
-    --add-overlay-alpha=0.5 \
+    --mask-alpha=0.5 \
     --colored
 ```
 

--- a/tf_bodypix/cli.py
+++ b/tf_bodypix/cli.py
@@ -434,10 +434,10 @@ class DrawMaskApp(AbstractWebcamFilterApp):
             ) * 255
         else:
             mask_image = mask * 255
-        if self.args.add_overlay_alpha is not None:
+        if self.args.mask_alpha is not None:
             self.timer.on_step_start('overlay')
             LOGGER.debug('mask.shape: %s (%s)', mask.shape, mask.dtype)
-            alpha = self.args.add_overlay_alpha
+            alpha = self.args.mask_alpha
             try:
                 if mask_image.dtype == tf.int32:
                     mask_image = tf.cast(mask, tf.float32)
@@ -458,9 +458,15 @@ class DrawMaskSubCommand(AbstractWebcamFilterSubCommand):
     def add_arguments(self, parser: argparse.ArgumentParser):
         super().add_arguments(parser)
         parser.add_argument(
-            "--add-overlay-alpha",
+            "--mask-alpha",
             type=float,
             help="The opacity of mask overlay to add."
+        )
+        parser.add_argument(
+            "--add-overlay-alpha",
+            dest='mask_alpha',
+            type=float,
+            help="Deprecated, please use --mask-alpha instead."
         )
         parser.add_argument(
             "--colored",

--- a/tf_bodypix/cli.py
+++ b/tf_bodypix/cli.py
@@ -444,7 +444,7 @@ class DrawMaskApp(AbstractWebcamFilterApp):
             except TypeError:
                 pass
             output = np.clip(
-                image_array + mask_image * alpha,
+                image_array * (1 - alpha) + mask_image * alpha,
                 0.0, 255.0
             )
             return output


### PR DESCRIPTION
Previously didn't darken the image in order not to change it when adding the overlay mask (via `--add-overlay-alpha`).
But the overlay mask can be hard to see and it's common to darken the background in that case.