### PR TITLE
install dev and main dependencies together

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ venv-create:
 
 dev-install:
 	$(PIP) install -r requirements.build.txt
-	$(PIP) install -r requirements.dev.txt
-	$(PIP) install -r requirements.txt
+	$(PIP) install \
+		-r requirements.dev.txt \
+		-r requirements.txt
 
 
 dev-venv: venv-create dev-install


### PR DESCRIPTION
This is to avoid hiding version conflicts.

For example pylint may depend on a newer version of typing-extension. Whereas tensorflow depends on an older version. By installing them separately, the previously installed version may just get overridden, hiding the version conflict in that case.