### PR TITLE
fixed pypi badge url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TensorFlow BodyPix (TF BodyPix)
 
-[![PyPi version](https://pypip.in/v/tf-bodypix/badge.png)](https://pypi.org/project/tf-bodypix/)
+[![PyPi version](https://img.shields.io/pypi/v/tf-bodypix)](https://pypi.org/project/tf-bodypix/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A Python implementation of [body-pix](https://github.com/tensorflow/tfjs-models/tree/body-pix-v2.0.4/body-pix).


### PR DESCRIPTION
The `pypip.in` URL doesn't seem to work anymore, switching to `shields.io`.