### PR TITLE
fix UnicodeDecodeError with newly downloaded model.json

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,3 +4,4 @@ pylint==2.10.2
 pytest==6.2.5
 pytest-watch==4.2.0
 setuptools-scm==6.3.2
+types-requests==2.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ tensorflow==2.7.0; python_version >= "3.7"
 tensorflow-estimator==2.6.0; python_version < "3.7"
 tensorflow-estimator==2.7.0; python_version >= "3.7"
 tfjs-graph-converter==1.4.2
+requests>=2.26.0

--- a/tf_bodypix/download.py
+++ b/tf_bodypix/download.py
@@ -84,7 +84,7 @@ def download_model(model_path: str) -> str:
     except UnicodeDecodeError as exc:
         LOGGER.error(
             'failed to process %r due to %r',
-            local_model_json_path, exc, exc_info=1
+            local_model_json_path, exc, exc_info=True
         )
         raise DownloadError(
             'failed to process %r due to %r' % (

--- a/tf_bodypix/download.py
+++ b/tf_bodypix/download.py
@@ -5,7 +5,7 @@ import re
 
 from hashlib import md5
 
-import tensorflow as tf
+from tf_bodypix.utils.io import download_file_to, get_default_cache_dir
 
 
 LOGGER = logging.getLogger(__name__)
@@ -70,11 +70,13 @@ def download_model(model_path: str) -> str:
         + os.path.basename(local_name_part)
     )
     LOGGER.debug('local_name: %r', local_name)
-    cache_subdir = os.path.join('tf-bodypix', local_name)
-    local_model_json_path = tf.keras.utils.get_file(
-        'model.json',
-        model_path,
-        cache_subdir=cache_subdir,
+    cache_dir = get_default_cache_dir(
+        cache_subdir=os.path.join('tf-bodypix', local_name)
+    )
+    local_model_json_path = download_file_to(
+        source_url=model_path,
+        local_path=os.path.join(cache_dir, 'model.json'),
+        skip_if_exists=True
     )
     local_model_path = os.path.dirname(local_model_json_path)
     LOGGER.debug('local_model_json_path: %r', local_model_json_path)
@@ -100,9 +102,9 @@ def download_model(model_path: str) -> str:
     })
     LOGGER.debug('weights_manifest_paths: %s', weights_manifest_paths)
     for weights_manifest_path in weights_manifest_paths:
-        local_model_json_path = tf.keras.utils.get_file(
-            os.path.basename(weights_manifest_path),
-            model_base_path + '/' + weights_manifest_path,
-            cache_subdir=cache_subdir,
+        local_model_json_path = download_file_to(
+            source_url=model_base_path + '/' + weights_manifest_path,
+            local_path=os.path.join(cache_dir, os.path.basename(weights_manifest_path)),
+            skip_if_exists=True
         )
     return local_model_path

--- a/tf_bodypix/utils/io.py
+++ b/tf_bodypix/utils/io.py
@@ -7,6 +7,7 @@ import requests
 
 
 DEFAULT_KERAS_CACHE_DIR = '~/.keras'
+DEFAULT_USER_AGENT = 'tf-bodypix'
 
 
 def strip_url_suffix(path: str) -> str:
@@ -29,11 +30,14 @@ def get_default_cache_dir(
 def download_file_to(
     source_url: str,
     local_path: str,
+    user_agent: str = DEFAULT_USER_AGENT,
     skip_if_exists: bool = True
 ):
     if skip_if_exists and os.path.exists(local_path):
         return local_path
-    response = requests.get(source_url)
+    response = requests.get(source_url, headers={
+        'User-Agent': user_agent
+    })
     response.raise_for_status()
     local_path_path = Path(local_path)
     local_path_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tf_bodypix/utils/io.py
+++ b/tf_bodypix/utils/io.py
@@ -1,7 +1,14 @@
 import os
 from hashlib import md5
+from pathlib import Path
+from typing import Optional
+
+import requests
 
 import tensorflow as tf
+
+
+DEFAULT_KERAS_CACHE_DIR = '~/.keras'
 
 
 def strip_url_suffix(path: str) -> str:
@@ -9,6 +16,29 @@ def strip_url_suffix(path: str) -> str:
     if qs_index > 0:
         return path[:qs_index]
     return path
+
+
+def get_default_cache_dir(
+    cache_dir: Optional[str] = None,
+    cache_subdir: Optional[str] = None
+):
+    result = os.path.expanduser(cache_dir or DEFAULT_KERAS_CACHE_DIR)
+    if cache_subdir:
+        result = os.path.join(result, cache_subdir)
+    return result
+
+
+def download_file_to(
+    source_url: str,
+    local_path: str,
+    skip_if_exists: bool = True
+):
+    if skip_if_exists and os.path.exists(local_path):
+        return local_path
+    response = requests.get(source_url)
+    response.raise_for_status()
+    Path(local_path).write_bytes(response.content)
+    return local_path
 
 
 def get_file(file_path: str, download: bool = True) -> str:

--- a/tf_bodypix/utils/io.py
+++ b/tf_bodypix/utils/io.py
@@ -35,7 +35,9 @@ def download_file_to(
         return local_path
     response = requests.get(source_url)
     response.raise_for_status()
-    Path(local_path).write_bytes(response.content)
+    local_path_path = Path(local_path)
+    local_path_path.parent.mkdir(parents=True, exist_ok=True)
+    local_path_path.write_bytes(response.content)
     return local_path
 
 

--- a/tf_bodypix/utils/io.py
+++ b/tf_bodypix/utils/io.py
@@ -5,8 +5,6 @@ from typing import Optional
 
 import requests
 
-import tensorflow as tf
-
 
 DEFAULT_KERAS_CACHE_DIR = '~/.keras'
 
@@ -46,12 +44,16 @@ def get_file(file_path: str, download: bool = True) -> str:
         return file_path
     if os.path.exists(file_path):
         return file_path
-    local_path = tf.keras.utils.get_file(
+    cache_dir = get_default_cache_dir()
+    local_path = os.path.join(
+        cache_dir,
         (
             md5(file_path.encode('utf-8')).hexdigest()
             + '-'
             + os.path.basename(strip_url_suffix(file_path))
-        ),
-        file_path
+        )
     )
-    return local_path
+    return download_file_to(
+        source_url=file_path,
+        local_path=local_path
+    )


### PR DESCRIPTION
part of #150

The HTTP server for `storage.googleapis.com` now seems to respond with `gzip` irrespective of whether it is supported by the client. [tf.keras.utils.get_file](https://www.tensorflow.org/api_docs/python/tf/keras/utils/get_file) doesn't seem to support that and saves the gzipped content instead. Switched to using `tequests` which does seem to support gzip encoding transparently. The current implementation wouldn't be suitable for very large files but that isn't usually the case.